### PR TITLE
latLonToUTM optionally takes a UTM zone.

### DIFF
--- a/utm.converter.js
+++ b/utm.converter.js
@@ -320,8 +320,9 @@ var UTMConverter = {
      * Convert latitude and longitude to UTM
      *
      * @params  {Object} latlon: Latitude and longitude coordinates in decimal
+     * @params  {Integer} zone: The UTM zone (optional)
      */
-    latLonToUTM: function(latlon) {
+    latLonToUTM: function(latlon, zone) {
 
       var lat = latlon.lat;
       var lon = latlon.lon;
@@ -335,8 +336,10 @@ var UTMConverter = {
         // Convert to radians
         lat = UTMConverter.utils.degreeToRadian(lat);
 
-        // Calculate UTM zone number
-        var zone = UTMConverter.utils.calcUTMZone(lon);
+        // Calculate UTM zone number if one is not provided
+        if (zone == undefined) {
+          var zone = UTMConverter.utils.calcUTMZone(lon);
+        }
 
         // Calculate UTM zone central meridian
         var zoneCM = UTMConverter.utils.calcCentralMeridian(zone);


### PR DESCRIPTION
Hi, I'm needing to use something like this where the zone for projecting into UTM from latlong can be set - that way a polygon expressed in geographic coordinates can be projected into one zone, even if it crosses zone boundaries

Thoughts?
